### PR TITLE
Add test for componentarrays and AD systems

### DIFF
--- a/test/autodiff/component_arrays.jl
+++ b/test/autodiff/component_arrays.jl
@@ -1,0 +1,62 @@
+using ComponentArrays
+using DiffEqFlux, DifferentialEquations, Plots
+using UnPack
+
+
+"""
+    To test whether `ComponentArray` (exported from `ComponentArrays`) is compatible with AD (auto-diff) systems.
+
+Borrowed from DiffEqFlux.jl documentation:
+https://diffeqflux.sciml.ai/stable/examples/neural_ode_flux/
+"""
+function main()
+    # u0 = Float32[2.; 0.]
+    u0 = ComponentArray(a=2.0, b=0.0)
+    datasize = 30
+    tspan = (0.0f0,1.5f0)
+
+    function trueODEfunc(du,u,p,t)
+        true_A = [-0.1 2.0; -2.0 -0.1]
+        @unpack a, b = u
+        tmp = ([a^3, b^3]'true_A)'
+        du.a, du.b = tmp
+    end
+    t = range(tspan[1],tspan[2],length=datasize)
+    prob = ODEProblem(trueODEfunc,u0,tspan)
+    ode_data = Array(solve(prob,Tsit5(),saveat=t))
+
+    dudt2 = Chain(x -> x.^3,
+                  Dense(2,50,tanh),
+                  Dense(50,2))
+    p,re = Flux.destructure(dudt2) # use this p as the initial condition!
+    dudt(u,p,t) = re(p)(u) # need to restructure for backprop!
+    prob = ODEProblem(dudt,u0,tspan)
+
+    function predict_n_ode()
+        Array(solve(prob,Tsit5(),u0=u0,p=p,saveat=t))
+    end
+
+    function loss_n_ode()
+        pred = predict_n_ode()
+        loss = sum(abs2,ode_data .- pred)
+        loss
+    end
+
+    loss_n_ode() # n_ode.p stores the initial parameters of the neural ODE
+
+    cb = function (;doplot=false) # callback function to observe training
+        pred = predict_n_ode()
+        display(sum(abs2,ode_data .- pred))
+        # plot current prediction against data
+        pl = scatter(t,ode_data[1,:],label="data")
+        scatter!(pl,t,pred[1,:],label="prediction")
+        display(plot(pl))
+        return false
+    end
+
+    # Display the ODE with the initial parameter values.
+    cb()
+
+    data = Iterators.repeated((), 1000)
+    Flux.train!(loss_n_ode, Flux.params(u0,p), data, ADAM(0.05), cb = cb)
+end


### PR DESCRIPTION
Resolves #16.

Loss history is as follows.

The tutorial is borrowed from [DiffEqFlux.jl's documentation](https://diffeqflux.sciml.ai/stable/examples/neural_ode_flux/) and modified for this test.
<details>
<summary>Click to toggle contents of `loss history`</summary>

```julia
julia> main()
135.6484981926943
123.20582383511532
109.05862874406634
100.38772981537093
98.85762708383626
96.5973931318496
93.09239958086748
91.27499811258774
90.46542396329592
90.08561162622215
89.75222953443509
89.13582823253668
88.06244135762469
86.49505975979646
84.43784649428484
81.91053770614508
79.00586686879845
75.82410643466301
72.15700562536009
67.19915853335364
61.61666461496443
54.597928904221064
47.21365786761153
43.682897301515496
43.67644024558271
44.3855341223455
41.7075948389611
36.9385063085275
42.46148286243595
38.75310713702262
34.15815726597047
36.12118807900447
34.46400723076714
27.918953931388778
26.89296495198012
24.905061280044123
20.034042216879556
20.122973987955397
19.05443869583489
17.987252624278554
19.661981803840924
19.308309676127756
17.47407153960309
17.70870168255241
15.09834802460161
12.141375942200533
8.049688064512805
8.305977527598525
6.478600908724806
9.879780046268294
16.244439035127503
9.845313069565908
5.678099112334374
9.057752223246053
5.167444087422383
8.826444462434923
8.319047687140698
5.177434498187036
6.140854838357503
4.2262744031494
3.491232651488875
5.697478095711815
3.340767486994672
6.008071305971487
3.5034088204100695
3.8623195662934737
3.564489448337097
2.5495226930309314
3.66521197388166
3.7414655223296998
2.8773352219787682
2.9891021533956663
2.9515346272882423
2.11694601764058
2.341567769682094
2.548730869232479
2.0245132912679655
2.3882035078478268
2.179187717437329
1.8731247316691464
2.0152170294350698
1.7891551138762687
1.6897992055434805
1.882458316268504
1.824960739681637
1.7058195213454634
1.7199499718190605
1.5845005728310781
1.4584529673986233
1.5151040158620301
1.4447334452009122
1.4470748941851082
1.4330355654935434
1.3255935113444934
1.314402753840426
1.2534745423228728
1.2427288195792536
1.2612863181811147
1.2070090865024259
1.1745800820925816
1.147064119875032
1.0914872990787368
1.0998639527167307
1.0820069341446588
1.0461079509288391
1.0310902333886378
0.9831221378972415
0.9666638580788514
0.9567662152530904
0.9277529665034949
0.9154928694893189
0.888332350074461
0.8600448229715548
0.85636166493715
0.8358638646702384
0.8206435645402363
0.804424775224628
0.7794877617961133
0.7711875559265199
0.7564596362017596
0.7406150619555536
0.7290760705084397
0.7103500196476166
0.7011890490051421
0.689614749363878
0.6759068622163572
0.6664500479149067
0.6518204328531612
0.645627847806429
0.634205090781984
0.6219942958201308
0.6142645245636107
0.6044273257489053
0.5961872763819366
0.5863652701932291
0.57755256894101
0.5699982950501028
0.5660220100283466
0.5578506301012239
0.5508428284665522
0.5427478741085096
0.539778596192321
0.5312376559642248
0.5233478891517905
0.5173660013763267
0.51291657349618
0.5044138247701221
0.5005947786342705
0.49856180492149377
0.495612397593994
0.4902064836231399
0.4844635366375614
0.47930061550620956
0.47643676774323906
0.4715248305088782
0.4659675106022272
0.46383542294247326
0.46016538408620494
0.4553354704286715
0.45086457150147297
0.4487307937495093
0.44537391928975956
0.44074548519317425
0.43594157618022733
0.43395946682012215
0.43252246236336267
0.4278150075392269
0.42586060161083134
0.4216917725308924
0.41975475878618246
0.41523341074606845
0.4150079609181839
0.4123875596954506
0.407714910112831
0.40509923802984055
0.4047460887139598
0.4006541540827139
0.39822532809287636
0.3963555047713285
0.3943096478421616
0.3906577906023665
0.3881521007021452
0.3857772554685408
0.3835593634437946
0.37998788345288603
0.37677127719914755
0.3740549699203494
0.3716920467972122
0.3694365077637087
0.36684546695370845
0.3641537028112098
0.3674547565915868
0.36221292189588034
0.3619649063171871
0.3597581108984728
0.357582430874683
0.35563737945057167
0.35361884996419735
0.3517572990825403
0.34955557903178003
0.3471786923063469
0.3444366312481503
0.34062965619064073
0.3381379670507887
0.3417132408987736
0.3381637465438631
0.3374951454755465
0.335373876547196
0.33130738581073715
0.3288817588300921
0.32854191217945844
0.32631975183583345
0.32299119600749265
0.3230018537460618
0.32109315943618294
0.3218987467729262
0.3165096093855818
```

</details>
